### PR TITLE
Select options: only set selected attribute when its true

### DIFF
--- a/src/formative/render.cljx
+++ b/src/formative/render.cljx
@@ -137,8 +137,12 @@
     [:textarea attrs (fu/escape-html (render-input-val field))]))
 
 (defn ^:private build-opt-tag [v text val]
-  (let [v (str v)]
-    [:option {:value v :selected (= val v)} text]))
+  (let [v (str v)
+        attrs {:value v}
+        attrs (if (= val v)
+                (assoc attrs :selected "true")
+                attrs)]
+    [:option attrs text]))
 
 (defmethod render-field :select [field]
   (let [attrs (get-input-attrs field [:name :id :class :autofocus


### PR DESCRIPTION
The `selected` attribute for an `option` element was always being set to either `true` or `false`. This breaks the selected attribute rendering (at least in Chrome). Only one option should ever have the `selected` attribute.

See http://jsbin.com/suwojito/1/

Output:

``` clojure
user=> (build-opt-tag "foo" "bar" "foo")
[:option {:selected "true", :value "foo"} "bar"]
user=> (build-opt-tag "foo" "bar" "quux")
[:option {:value "foo"} "bar"]
```
