### PR TITLE
Replace nobr elements with 'white-space: nowrap'

### DIFF
--- a/src/formative/render.cljc
+++ b/src/formative/render.cljc
@@ -197,7 +197,7 @@
                        [:span.cb-input-shell
                         (render-field {:name fname :id id :checked (contains? vals (str oval))
                                        :type :checkbox :value (str oval)})] " "
-                       [:span.cb-label [:nobr olabel]]]]))]
+                       [:span.cb-label [:span {:style {:white-space "nowrap"}} olabel]]]]))]
     [:div.checkboxes
      ;; FIXME: this prevents checkbox values from being absent in the submitted
      ;; request, but at the cost of including an empty value which must be
@@ -229,7 +229,7 @@
                                                   :checked (= val (str oval))
                                                   :value oval})]
                           " "
-                          [:span.radio-label [:nobr olabel]]]]))]
+                          [:span.radio-label [:span {:style {:white-space "nowrap"}} olabel]]]]))]
     [:div.radios
      (for [[oval olabel subopts] opts]
        (if (empty? subopts)


### PR DESCRIPTION
Hi, I'm using this library at work, and we were running into some trouble with the `<nobr>` elements. In this PR, I've replaced them with `<span>`s with `white-space: nowrap;` (as recommended [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nobr)).

Fixes #35 